### PR TITLE
Include <stdlib.h> for malloc, free (Ubuntu-14.04)

### DIFF
--- a/groestlcoin.cpp
+++ b/groestlcoin.cpp
@@ -6,6 +6,7 @@
 
 #include <string.h>
 #include <stdint.h>
+#include <stdlib.h>
 #include "cuda_groestlcoin.h"
 #include <openssl/sha.h>
 

--- a/myriadgroestl.cpp
+++ b/myriadgroestl.cpp
@@ -6,6 +6,7 @@
 
 #include <string.h>
 #include <stdint.h>
+#include <stdlib.h>
 #include <openssl/sha.h>
 
 extern bool opt_benchmark;


### PR DESCRIPTION
I needed to include stdlib.h to compile on Linux, specifically Ubuntu 14.04
